### PR TITLE
fix added for line numbering using lineno package

### DIFF
--- a/template.tex
+++ b/template.tex
@@ -10,7 +10,6 @@
     [#- if options.reference_style == "vancouver" -#] sn-vancouver [#- endif -#]
     [#- if options.pdf_latex -#]                     , pdflatex    [#- endif -#]
     [#- if options.referee -#]                       , referee     [#- endif -#]
-    [#- if options.line_numbers -#]                  , lineno      [#- endif -#]
     [#- if options.numbered_referencing -#]          , Numbered    [#- endif -#]
     [#- if options.formatting == "twocolumn" -#]     , iicol       [#- endif -#]
     ]{sn-jnl}
@@ -18,6 +17,7 @@
 
 \usepackage{graphicx}%
 \usepackage{multirow}%
+\usepackage[mathlines]{lineno}
 \usepackage{amsmath,amssymb,amsfonts}%
 \usepackage{amsthm}
 \usepackage{mathrsfs}
@@ -30,6 +30,51 @@
 \usepackage{algorithmicx}
 \usepackage{algpseudocode}
 \usepackage{listings}
+\usepackage{etoolbox}
+
+
+% line numbering of equation lines using amsmath (https://tex.stackexchange.com/questions/461186/how-to-use-lineno-with-amsmath-align)
+%% Patch 'normal' math environments:
+\newcommand*\linenomathpatch[1]{%
+  \cspreto{#1}{\linenomath}%
+  \cspreto{#1*}{\linenomath}%
+  \csappto{end#1}{\endlinenomath}%
+  \csappto{end#1*}{\endlinenomath}%
+}
+%% Patch AMS math environments:
+\newcommand*\linenomathpatchAMS[1]{%
+  \cspreto{#1}{\linenomathAMS}%
+  \cspreto{#1*}{\linenomathAMS}%
+  \csappto{end#1}{\endlinenomath}%
+  \csappto{end#1*}{\endlinenomath}%
+}
+
+%% Definition of \linenomathAMS depends on whether the mathlines option is provided
+\expandafter\ifx\linenomath\linenomathWithnumbers
+  \let\linenomathAMS\linenomathWithnumbers
+  %% The following line gets rid of an extra line numbers at the bottom:
+  \patchcmd\linenomathAMS{\advance\postdisplaypenalty\linenopenalty}{}{}{}
+\else
+  \let\linenomathAMS\linenomathNonumbers
+\fi
+
+\linenomathpatch{equation}
+\linenomathpatchAMS{gather}
+\linenomathpatchAMS{multline}
+\linenomathpatchAMS{align}
+\linenomathpatchAMS{alignat}
+\linenomathpatchAMS{flalign}
+
+% Disable line numbering during measurement step of multline
+\makeatletter
+\patchcmd{\mmeasure@}{\measuring@true}{
+  \measuring@true
+  \ifnum-\linenopenaltypar>\interdisplaylinepenalty
+    \advance\interdisplaylinepenalty-\linenopenalty
+  \fi
+  }{}{}
+\makeatother
+
 
 
 [- IMPORTS -]
@@ -64,6 +109,10 @@
 \newtheorem{remark}{Remark}
 \newtheorem{definition}{Definition}
 [# endif -#]
+
+[#- if options.line_numbers -#] 
+\linenumbers
+[#- endif -#]
 
 \begin{document}
 

--- a/template.yml
+++ b/template.yml
@@ -134,6 +134,7 @@ files:
   - sn-jnl.cls
   - sn-apacite.bst
   - sn-aps.bst
+  - sn-basic.bst
   - sn-chicago.bst
   - sn-mathphys.bst
   - sn-nature.bst
@@ -155,4 +156,6 @@ packages:
   - multirow
   - textcomp
   - xcolor
+  - lineno
+  - etoolbox
 myst: v1


### PR DESCRIPTION
The original Nature Springer template used a lazy method for line numbering that made no sense. I have replaced it with a line numbering using the `lineno` package and [this](https://tex.stackexchange.com/questions/461186/how-to-use-lineno-with-amsmath-align) fix so that `amsmath` equations have their lines numbered too.

I also added the `sn-basic.bst` to the `tempate.yml` file.

I have tested it only on one tex file but it looks like it works.